### PR TITLE
Add get_current_situation() function to FrayCombatStateMachine

### DIFF
--- a/addons/fray/src/state_mgmt/combat_state_machine.gd
+++ b/addons/fray/src/state_mgmt/combat_state_machine.gd
@@ -112,6 +112,12 @@ func get_situation(situation_name: StringName) -> FrayRootState:
 		return _situations[situation_name]
 	return null
 
+## Returns the current situation
+func get_current_situation() -> FrayRootState:
+	if has_situation(current_situation):
+		return _situations[current_situation]
+	return null
+
 ## Returns true if a situation with the given name exists
 func has_situation(situation_name: StringName) -> bool:
 	return _situations.has(situation_name)


### PR DESCRIPTION
Title.

Alternative is `combat_state_machine.get_situation(combat_state_machine.current_situation)`, which is too verbose.