### PR TITLE
Add support for shared state context

### DIFF
--- a/src/state_mgmt/state/compound_state.gd
+++ b/src/state_mgmt/state/compound_state.gd
@@ -611,6 +611,8 @@ func input(event: InputEvent) -> void:
 
 ## Propogates unhandled input to this state then child states.
 func unhandled_input(event: InputEvent) -> void:
+	_unhandled_input_impl(event)
+	
 	if not _states.is_empty():
 		var cur_state: FrayState = get_current_state()
 		if cur_state != null:
@@ -618,8 +620,6 @@ func unhandled_input(event: InputEvent) -> void:
 				cur_state.unhandled_input(event)
 			elif cur_state != null:
 				cur_state._unhandled_input_impl(event)
-
-	_unhandled_input_impl(event)
 
 ## Process child states then this state.
 ## This method is intended to only be used by the [FrayStateMachine].

--- a/src/state_mgmt/state/compound_state.gd
+++ b/src/state_mgmt/state/compound_state.gd
@@ -581,7 +581,12 @@ func get_active_states_info() -> Dictionary:
 
 ## Readies child states then this state.
 ## This method is intended to only be used by the [FrayStateMachine].
+## [br]
+## [b]WARN:[/b] The dictionary provided to the context argument will be made read-only. 
 func ready(context: Dictionary) -> void:
+	if not context.is_read_only():
+		context.make_read_only()
+
 	for state_name in _states:
 		var state: FrayState = _states[state_name]
 		

--- a/src/state_mgmt/state/compound_state.gd
+++ b/src/state_mgmt/state/compound_state.gd
@@ -22,9 +22,6 @@ signal state_removed(name: StringName, state: FrayState)
 ## Emitted when a state is renamed.
 signal state_renamed(name: StringName, state: FrayState)
 
-#TODO: The transitioned signal may need to be rethought.
-# It seems fine for simple systems but when hierarchies are involved i'm not sure
-# what the most useful way to represent changes might be.
 ## Emitted when the current state is changes.
 signal transitioned(from: StringName, to: StringName)
 
@@ -98,18 +95,6 @@ func _exit_impl() -> void:
 	
 	if not is_persistent:
 		_current_state = ""
-
-
-func _input_impl(event: InputEvent) -> void:
-	var cur_state := get_current_state()
-	if cur_state is FrayCompoundState:
-		cur_state._input_impl(event)
-
-
-func _unhandled_input_impl(event: InputEvent) -> void:
-	var cur_state := get_current_state()
-	if cur_state is FrayCompoundState:
-		cur_state._unhandled_input_impl(event)
 
 
 func _is_done_processing_impl() -> bool:
@@ -218,9 +203,6 @@ func add_state(name: StringName, state: FrayState) -> void:
 	if _ERR_FAILED_TO_ADD_STATE(name, state):
 		return
 
-	if state is FrayCompoundState and not state._condition_func_by_name.is_empty():
-		push_warning("Sub state contains conditions. These conditions will be ignored.")
-
 	state._root_ref = _root_ref if _root_ref else weakref(self)
 	state._parent_ref = weakref(self)
 	_states[name] = state
@@ -229,7 +211,7 @@ func add_state(name: StringName, state: FrayState) -> void:
 	if _states.size() == 1:
 		_start_state = name
 
-	state._ready_impl()
+	state._enter_tree_impl()
 	state_added.emit(name, state)
 
 
@@ -597,8 +579,45 @@ func get_active_states_info() -> Dictionary:
 
 	return {path = "/".join(active_state_names), states = active_state_objects}
 
+## Readies child states then this state.
+## This method is intended to only be used by the [FrayStateMachine].
+func ready(context: Dictionary) -> void:
+	for state_name in _states:
+		var state: FrayState = _states[state_name]
+		
+		if state is FrayCompoundState:
+			state.ready(context)
+		else:
+			state._ready_impl(context)
+
+	_ready_impl(context)
+
+## Propogates input to this state then child states.
+func input(event: InputEvent) -> void:
+	_input_impl(event)
+
+	if not _states.is_empty():
+		var cur_state: FrayState = get_current_state()
+		if cur_state != null:
+			if cur_state is FrayCompoundState:
+				cur_state.input(event)
+			elif cur_state != null:
+				cur_state._input_impl(event)
+
+## Propogates unhandled input to this state then child states.
+func unhandled_input(event: InputEvent) -> void:
+	if not _states.is_empty():
+		var cur_state: FrayState = get_current_state()
+		if cur_state != null:
+			if cur_state is FrayCompoundState:
+				cur_state.unhandled_input(event)
+			elif cur_state != null:
+				cur_state._unhandled_input_impl(event)
+
+	_unhandled_input_impl(event)
 
 ## Process child states then this state.
+## This method is intended to only be used by the [FrayStateMachine].
 func process(delta: float) -> void:
 	if not _states.is_empty():
 		var cur_state: FrayState = get_current_state()
@@ -611,6 +630,7 @@ func process(delta: float) -> void:
 
 
 ## Physics process child states then this state.
+## This method is intended to only be used by the [FrayStateMachine].
 func physics_process(delta: float) -> void:
 	if not _states.is_empty():
 		var cur_state: FrayState = get_current_state()

--- a/src/state_mgmt/state/state.gd
+++ b/src/state_mgmt/state/state.gd
@@ -58,12 +58,12 @@ func _enter_tree_impl() -> void:
 
 
 ## [code]Virtual method[/code] invoked when the state is being processed. [kbd]delta[/kbd] is in seconds.
-func _process_impl(_delta: float) -> void:
+func _process_impl(delta: float) -> void:
 	pass
 
 
 ## [code]Virtual method[/code] invoked when the state is being physics processed. [kbd]delta[/kbd] is in seconds.
-func _physics_process_impl(_delta: float) -> void:
+func _physics_process_impl(delta: float) -> void:
 	pass
 
 

--- a/src/state_mgmt/state/state.gd
+++ b/src/state_mgmt/state/state.gd
@@ -34,10 +34,11 @@ func _is_done_processing_impl() -> bool:
 	return true
 
 
-## [code]Virtual method[/code] invoked when this state is added to the state machine tree.
-func _ready_impl() -> void:
+## [code]Virtual method[/code] invoked when the state machine is initialized. Child states are readied before parent states.
+## [br]
+## [kbd]context[/kbd] is read-only dictionary which provides a way to pass data which is available to all states within a hierachy.
+func _ready_impl(context: Dictionary) -> void:
 	pass
-
 
 ## [code]Virtual method[/code] invoked when the state is entered.
 ## [br]
@@ -51,12 +52,17 @@ func _exit_impl() -> void:
 	pass
 
 
-## [code]Virtual method[/code] invoked when the state is being processed.
+## [code]Virtual method[/code] invokved when the state is added to the state machine hierarchy.
+func _enter_tree_impl() -> void:
+	pass
+
+
+## [code]Virtual method[/code] invoked when the state is being processed. [kbd]delta[/kbd] is in seconds.
 func _process_impl(_delta: float) -> void:
 	pass
 
 
-## [code]Virtual method[/code] invoked when the state is being physics processed.
+## [code]Virtual method[/code] invoked when the state is being physics processed. [kbd]delta[/kbd] is in seconds.
 func _physics_process_impl(_delta: float) -> void:
 	pass
 

--- a/src/state_mgmt/state_machine.gd
+++ b/src/state_mgmt/state_machine.gd
@@ -58,8 +58,6 @@ func _physics_process(delta: float) -> void:
 ## [br]
 ## [b]WARN:[/b] The dictionary provided to the context argument will be made read-only. 
 func initialize(context: Dictionary, root: FrayCompoundState) -> void:
-	context.make_read_only()
-
 	_root = root
 	_root.ready(context)
 	_root._enter_impl({})

--- a/src/state_mgmt/state_machine.gd
+++ b/src/state_mgmt/state_machine.gd
@@ -24,23 +24,21 @@ enum AdvanceMode {
 ## during both idle and physics frames regardless of advance mode.
 @export var advance_mode: AdvanceMode = AdvanceMode.IDLE
 
-## The root of this state machine.
-var root: FrayCompoundState:
-	get:
-		return root
-	set(value):
-		if root != null and root.transitioned.is_connected(_on_RootState_transitioned):
-			root.transitioned.disconnect(_on_RootState_transitioned)
+var _root: FrayCompoundState
 
-		root = value
-		root._ready_impl()
-		root._enter_impl({})
-		root.transitioned.connect(_on_RootState_transitioned)
+func _input(event: InputEvent) -> void:
+	if _can_process():
+		_root.input(event)
+
+
+func _unhandled_input(event: InputEvent):
+	if _can_process():
+		_root.unhandled_input(event)
 
 
 func _process(delta: float) -> void:
 	if _can_process():
-		root.process(delta)
+		_root.process(delta)
 
 		if advance_mode == AdvanceMode.IDLE:
 			advance()
@@ -48,11 +46,28 @@ func _process(delta: float) -> void:
 
 func _physics_process(delta: float) -> void:
 	if _can_process():
-		root.physics_process(delta)
+		_root.physics_process(delta)
 
 		if advance_mode == AdvanceMode.PHYSICS:
 			advance()
 
+## Used to initialize the root of the state machine.
+## [br]
+## [kbd]context[/kbd] is an optional dictionary which can pass read-only data to all states within the hierarchy. 
+## This data is accessible within a state's [method FrayState._ready_impl] method when it is invoked.
+## [br]
+## [b]WARN:[/b] The dictionary provided to the context argument will be made read-only. 
+func initialize(context: Dictionary, root: FrayCompoundState) -> void:
+	context.make_read_only()
+
+	_root = root
+	_root.ready(context)
+	_root._enter_impl({})
+	_root.transitioned.connect(_on_RootState_transitioned)
+
+## Returns the state machine root.
+func get_root() -> FrayCompoundState:
+	return _root
 
 ## Used to manually advance the state machine.
 func advance(input: Dictionary = {}, args: Dictionary = {}) -> bool:
@@ -67,7 +82,7 @@ func advance(input: Dictionary = {}, args: Dictionary = {}) -> bool:
 func get_current_state_name() -> StringName:
 	if _ERR_ROOT_NOT_SET("Failed to travel"):
 		return ""
-	return root.get_current_state_name()
+	return _root.get_current_state_name()
 
 
 ## Transitions from the current state to another one, following the shortest path.
@@ -79,7 +94,7 @@ func travel(to: StringName, args: Dictionary = {}) -> void:
 	if _ERR_ROOT_NOT_SET("Failed to travel"):
 		return
 
-	root.travel(to, args)
+	_root.travel(to, args)
 
 
 ## Goes directly to the given state if it exists.
@@ -90,7 +105,7 @@ func goto(path: StringName, args: Dictionary = {}) -> void:
 	if _ERR_ROOT_NOT_SET("Failed to go to state"):
 		return
 
-	root.goto(path, args)
+	_root.goto(path, args)
 
 
 ## Goes directly to the start state.
@@ -100,7 +115,7 @@ func goto_start(args: Dictionary = {}) -> void:
 	if _ERR_ROOT_NOT_SET("Failed to go to start state"):
 		return
 
-	root.goto_start(args)
+	_root.goto_start(args)
 
 
 ## Goes directly to the end state.
@@ -110,7 +125,7 @@ func goto_end(args: Dictionary = {}) -> void:
 	if _ERR_ROOT_NOT_SET("Failed to go to end state"):
 		return
 
-	root.goto_end(args)
+	_root.goto_end(args)
 
 
 ## [code]Virtual method[/code] used to implement [method advance] method.
@@ -119,15 +134,15 @@ func _advance_impl(input: Dictionary = {}, args: Dictionary = {}) -> bool:
 		push_warning("Failed to advance. Current state not set.")
 		return false
 
-	return root.advance(input, args)
+	return _root.advance(input, args)
 
 
 func _can_process() -> bool:
-	return root != null and active
+	return _root != null and active
 
 
 func _ERR_ROOT_NOT_SET(msg: String = "") -> bool:
-	if root == null:
+	if _root == null:
 		push_error("%s. Current state not set." % msg)
 		return true
 


### PR DESCRIPTION
# Added

- Added `FrayState._enter_tree_impl()` method. This method will be invoked when the state is added to the hierarchy.
- Added read-only context which is shared to all states. The context can be provided when initializing a state machine.
  ```
  state_machine.initialize({
     key1 = value1,
     key2 = value2
  }, FrayCompoundState.builder()
     .add_state(...)
     .transition(...)
  )
  ```

# Changed

- `FrayStateMachine` is no longer initialized by setting the root. Instead the root should be passed to the initialize method. The initialize method also contains a parameter to pass context.
   ```
   state_machine.initialize(context, root)
   ```
- `FrayState._ready_impl()` is no longer called when the state is added to the hierarchy. It is now called when the state is initialized

# Fixed

- `FrayStateMachine` now invokes `FrayState._input()` and `FrayState._unhandled_input()`. In the recent state management refactor I added input added these virtual functions but some how forgot to actually invoke them. 

# Related Issues

Fixes #72 